### PR TITLE
Make auto-assign configurable and actor-based

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,38 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add assignee
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_ASSIGNEES: ${{ vars.DEFAULT_ASSIGNEES }}
+        with:
+          script: |
+            const configAssignees = process.env.DEFAULT_ASSIGNEES
+              ? process.env.DEFAULT_ASSIGNEES.split(",").map((assignee) => assignee.trim()).filter(Boolean)
+              : [];
+            const assignees = configAssignees.length > 0 ? configAssignees : [context.actor];
+
+            const issueNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
+            if (!issueNumber) {
+              core.warning("No issue or pull request number found.");
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              assignees
+            });


### PR DESCRIPTION
### Motivation
- Ensure the auto-assign workflow works for issues and forked pull requests and does not fail due to permissions or hard-coded usernames.
- Make the default assignee configurable repository-wide and fall back to assigning the issue/PR author when no explicit default is set.

### Description
- Removed the hard-coded assignee from `.github/ISSUE_TEMPLATE/feature_request.md` so templates do not force a specific account.
- Replaced `pull_request` with `pull_request_target` and added explicit `permissions` (`issues: write` and `pull-requests: write`) in `.github/workflows/auto-assign.yml` to allow assigning PRs from forks.
- Read `DEFAULT_ASSIGNEES` from repo variables via the `DEFAULT_ASSIGNEES` env and use it when set, otherwise fall back to `context.actor` as the assignee.
- Consolidated assignment logic to compute the `issueNumber` once and call `github.rest.issues.addAssignees` with the resolved assignees.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738aeea5b48333aefe4184696c4e14)