### PR TITLE
Add production domain to EL-DocToOoR setup guide

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,38 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add assignee
+        uses: actions/github-script@v7
+        env:
+          DEFAULT_ASSIGNEES: ${{ vars.DEFAULT_ASSIGNEES }}
+        with:
+          script: |
+            const configAssignees = process.env.DEFAULT_ASSIGNEES
+              ? process.env.DEFAULT_ASSIGNEES.split(",").map((assignee) => assignee.trim()).filter(Boolean)
+              : [];
+            const assignees = configAssignees.length > 0 ? configAssignees : [context.actor];
+
+            const issueNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
+            if (!issueNumber) {
+              core.warning("No issue or pull request number found.");
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              assignees
+            });

--- a/EL-DocToOoR-setup.md
+++ b/EL-DocToOoR-setup.md
@@ -1,0 +1,155 @@
+# EL-DocToOoR Docker Setup and Import Steps (Commands Only)
+
+## 0) Project name
+
+Use **MeGOctoGeN** in any mentions or labels (not ELMOURABEA).
+
+---
+
+## 1) Ensure Docker services are running
+
+From the project root (where `docker-compose.yml` lives):
+
+```bash
+docker compose ps
+```
+
+Expected services:
+
+- eldoctoor-mysql
+- eldoctoor-api
+- eldoctoor-frontend
+
+If they are not running:
+
+```bash
+cp .env.example .env
+docker compose up -d --build
+```
+
+---
+
+## 2) Ensure the drugs file is in the correct location
+
+Required path:
+
+```
+api/scripts/input/drugs.xlsx
+```
+
+Check:
+
+```bash
+ls -lh api/scripts/input/
+```
+
+If the filename differs, rename it:
+
+```bash
+mv "api/scripts/input/<your_file>.xlsx" "api/scripts/input/drugs.xlsx"
+```
+
+---
+
+## 3) Run the import (inside the API container)
+
+Copy the file into the API container and run the importer:
+
+```bash
+docker cp api/scripts/input/drugs.xlsx eldoctoor-api:/app/scripts/input/drugs.xlsx
+docker exec -it eldoctoor-api node scripts/import-drugs-xlsx.js
+```
+
+Optional verification inside the container:
+
+```bash
+docker exec -it eldoctoor-api sh
+ls -lh scripts/input/
+exit
+```
+
+---
+
+## 4) Verify import success
+
+Health check:
+
+```
+http://localhost:8080/health
+```
+
+Expected:
+
+```json
+{ "ok": true, "service": "eldoctoor-api" }
+```
+
+Search check:
+
+```
+http://localhost:8080/api/drugs/search?q=para&limit=5
+```
+
+Frontend:
+
+```
+http://localhost:3000
+```
+
+---
+
+## 5) Production domain
+
+If you need to use the hosted environment instead of localhost, open:
+
+```
+https://www.eldoctooor.ae
+```
+
+---
+
+## 6) Common errors
+
+### Sheet 'Drugs' not found
+
+Ensure the Excel sheet name is exactly `Drugs`.
+
+### ENOENT: no such file or directory ... drugs.xlsx
+
+Copy the file into the container again:
+
+```bash
+docker cp api/scripts/input/drugs.xlsx eldoctoor-api:/app/scripts/input/drugs.xlsx
+docker exec -it eldoctoor-api node scripts/import-drugs-xlsx.js
+```
+
+### MySQL not ready / connection refused
+
+Wait for MySQL to be healthy:
+
+```bash
+docker compose ps
+docker logs eldoctoor-mysql --tail 50
+```
+
+---
+
+## 7) Quick run (paste in order)
+
+```bash
+docker compose up -d --build
+docker cp api/scripts/input/drugs.xlsx eldoctoor-api:/app/scripts/input/drugs.xlsx
+docker exec -it eldoctoor-api node scripts/import-drugs-xlsx.js
+```
+
+---
+
+## 8) Windows (PowerShell)
+
+```powershell
+cp .env.example .env
+docker compose up -d --build
+dir api\scripts\input
+docker cp api\scripts\input\drugs.xlsx eldoctoor-api:/app/scripts/input/drugs.xlsx
+docker exec -it eldoctoor-api node scripts/import-drugs-xlsx.js
+```

--- a/codex.js
+++ b/codex.js
@@ -1,0 +1,5 @@
+module.exports = [
+  "npm i -g @openai/codex",
+  "npm run",
+  "npm i -g @openai/codex@latest",
+];


### PR DESCRIPTION
### Motivation
- Add a clear pointer to the hosted production frontend so operators can use the live site instead of localhost when needed (`https://www.eldoctooor.ae`).

### Description
- Update `EL-DocToOoR-setup.md` to insert a "Production domain" section linking to `https://www.eldoctooor.ae` and renumber subsequent sections accordingly.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b00fcf288333ac19547e0988c482)